### PR TITLE
Added debug scene entry

### DIFF
--- a/modules/globals/level_manager.gd
+++ b/modules/globals/level_manager.gd
@@ -1,21 +1,43 @@
 extends Node2D
 
-@export var current_level : Node2D
+signal main_ready
+
+var current_level : Node2D
+var custom_scene_path : String
+
 @export var fade_time := 0.5
+
 @onready var fade_screen = %TransitionOverlay
 
 @onready var entrances : Dictionary
 
+@export var default_level : PackedScene
+
 var player
 var transitioning := false
 
+func _ready():
+	if get_tree().current_scene.name != "Main":
+		custom_scene_path = get_tree().current_scene.scene_file_path
+		get_tree().change_scene_to_file("res://modules/globals/main.tscn")
+	main_ready.connect(_main_ready)
+	
+func _main_ready():
+	player = get_tree().get_first_node_in_group("player")
+
+	if custom_scene_path:
+		_swap_level(custom_scene_path)
+	else:
+		_swap_level(default_level.resource_path)
+		
 func change_level(path : String, entrance_name : String = ""):
 	if transitioning:
 		return
 	transitioning = true
 	
 	player = get_tree().get_first_node_in_group("player")
-	
+	player.lock_camera = true
+
 	# save level state
 	var tween = get_tree().create_tween()
 	tween.set_parallel(false)
@@ -25,14 +47,13 @@ func change_level(path : String, entrance_name : String = ""):
 	tween.finished.connect(_transition_complete)
 
 func _swap_level(path : String, entrance_name : String = ""):
-	player.lock_camera = true
-
 	var packed = load(path)
 	var level = packed.instantiate()
 	add_child(level)
 	
-	remove_child(current_level)
-	current_level.queue_free()
+	if current_level:
+		remove_child(current_level)
+		current_level.queue_free()
 	current_level = level
 	
 	_get_entrances()

--- a/modules/globals/level_manager.tscn
+++ b/modules/globals/level_manager.tscn
@@ -1,13 +1,11 @@
 [gd_scene load_steps=3 format=3 uid="uid://dt2uaqdd4hxiu"]
 
 [ext_resource type="Script" path="res://modules/globals/level_manager.gd" id="1_dvekp"]
-[ext_resource type="PackedScene" uid="uid://c21tx8txxbw18" path="res://modules/levels/debug/testing_grounds/testing_grounds.tscn" id="2_vwsl8"]
+[ext_resource type="PackedScene" uid="uid://c21tx8txxbw18" path="res://modules/levels/debug/testing_grounds/testing_grounds.tscn" id="2_4v8u8"]
 
-[node name="LevelManager" type="Node2D" node_paths=PackedStringArray("current_level")]
+[node name="LevelManager" type="Node2D"]
 script = ExtResource("1_dvekp")
-current_level = NodePath("TestingGrounds")
-
-[node name="TestingGrounds" parent="." instance=ExtResource("2_vwsl8")]
+default_level = ExtResource("2_4v8u8")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 

--- a/modules/globals/main.gd
+++ b/modules/globals/main.gd
@@ -1,0 +1,4 @@
+extends Node2D
+
+func _ready():
+	LevelManager.main_ready.emit()

--- a/modules/globals/main.tscn
+++ b/modules/globals/main.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=3 format=3 uid="uid://b8ywe7vivb1en"]
+[gd_scene load_steps=4 format=3 uid="uid://b8ywe7vivb1en"]
 
+[ext_resource type="Script" path="res://modules/globals/main.gd" id="1_2uu7l"]
 [ext_resource type="PackedScene" uid="uid://cyh345au8bpro" path="res://modules/entities/player/player.tscn" id="2_wwsun"]
 [ext_resource type="PackedScene" uid="uid://gna64jq1jkf1" path="res://modules/ui/debug/num_keys/num_keys.tscn" id="3_wjh11"]
 
 [node name="Main" type="Node2D"]
+script = ExtResource("1_2uu7l")
 
 [node name="Player" parent="." instance=ExtResource("2_wwsun")]
 

--- a/modules/levels/placeholder_mom_house/stat_replenish.gd
+++ b/modules/levels/placeholder_mom_house/stat_replenish.gd
@@ -2,6 +2,8 @@ extends Node2D
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	# NATE: I added this await line because if we run this from 
+	await LevelManager.main_ready
 	var player = get_tree().get_first_node_in_group("player")
 	print(player.health_component.health)
 	player.health_component.health = player.health_component.max_health


### PR DESCRIPTION
When we first load our game, if the name of the scene is not "main", we save the path of the current scene, change the scene to main, and call `_swap_level` on our saved path. This makes it so that we can effectively test any scene with "run current scene" including enemies and objects

Also added "default level" export variable in LevelManager that defines a default scene so that it runs in a main container.