### PR TITLE
Moved origin of testing grounds

### DIFF
--- a/modules/levels/debug/testing_grounds/testing_grounds.tscn
+++ b/modules/levels/debug/testing_grounds/testing_grounds.tscn
@@ -319,7 +319,6 @@ sources/0 = SubResource("TileSetAtlasSource_45hkk")
 
 [node name="TestingGrounds" type="Node2D"]
 y_sort_enabled = true
-position = Vector2(-784, -384)
 metadata/_edit_horizontal_guides_ = [-188.0, 611.0]
 metadata/_edit_vertical_guides_ = [915.0]
 


### PR DESCRIPTION
- Moved the origin of testing grounds back to (0,0). Having it moved away from (0,0) so that the player would spawn in the dungeon area made it so that the transition zone (from Mom's House) would spawn the player outside of the map with no way of getting back in.

- Although it does make it so that the player has to walk to the dungeon, I think it will be important in the future as we mess with save states.